### PR TITLE
Improve wording and clarify

### DIFF
--- a/resources/articles/platform_adhesion/skirt_gap.md
+++ b/resources/articles/platform_adhesion/skirt_gap.md
@@ -2,6 +2,7 @@ Skirt Distance
 ====
 This setting adjusts the distance between the model and the skirt.
 
-By keeping enough distance, the skirt won't attach to the model, reducing the elephant's feet effect.
+This is the distance between the closest line of the skirt and the model. 
+If the skirt consists of multiple lines, these additional lines will be placed further away from the model.
 
-This is the distance of the closest line of the skirt. If the skirt consists of multiple lines, those will be placed further.
+By keeping enough distance, the skirt won't attach to the model, reducing the elephant's feet effect.


### PR DESCRIPTION
Improve wording and clarify.
Move order of explanation so that it corresponds to the order:
- What is the setting (short explanation)
- What is the setting (detailed explanation)
- Why use this setting / When to use this setting